### PR TITLE
feat: add base-files_release-info

### DIFF
--- a/3.12-24.04/rockcraft.yaml
+++ b/3.12-24.04/rockcraft.yaml
@@ -20,6 +20,7 @@ parts:
     stage-packages:
       - rabbitmq-server_bins
       - base-files_chisel
+      - base-files_release-info
       - dash_bins
       - erlang-base_bins
       - erlang-crypto_modules


### PR DESCRIPTION
Add `base-files_release-info` to enable sbom generation and vulnerability scanning.